### PR TITLE
Fix intermittent radar tile tearing: copy-on-write region merge in FrameStore

### DIFF
--- a/src/librewxr/data/store.py
+++ b/src/librewxr/data/store.py
@@ -87,10 +87,18 @@ class FrameStore:
             for name, data in list(frame.regions.items()):
                 frame.regions[name] = self._to_memmap(frame.timestamp, name, data)
 
-            # Merge into existing frame if same timestamp
+            # Merge into existing frame if same timestamp.
+            # Copy-on-write: build a NEW regions dict and swap the reference instead of
+            # mutating in place. The tile warmer/renderer captures `frame.regions` (a live
+            # dict ref) and renders many tiles over several seconds; an in-place `.update()`
+            # mid-warm makes tiles rendered before the swap read the old arrays and tiles
+            # after read the new ones -> a visible seam ("tearing") on any frame whose data
+            # updates mid-warm. Swapping the reference leaves in-flight renders on a
+            # consistent snapshot (region arrays are never mutated in place, so sharing the
+            # old arrays with an in-flight reader is safe).
             for existing in self._frames:
                 if existing.timestamp == frame.timestamp:
-                    existing.regions.update(frame.regions)
+                    existing.regions = {**existing.regions, **frame.regions}
                     return None, True
 
             evicted_ts = None


### PR DESCRIPTION
## Summary

`FrameStore.add_frame` merges late-arriving region data into an already-stored frame by **mutating its `regions` dict in place**, while the tile warmer (and the on-demand renderer) hold a **live reference** to that same dict and render many tiles from it over several seconds. When a frame's data is merged mid-render, tiles produced before the merge use the old arrays and tiles produced after use the new ones — producing a visible **seam ("tearing")** in the composited radar for that frame. This makes the merge copy-on-write so in-flight renders keep a consistent snapshot.

## Symptoms

- Intermittent horizontal/vertical seams in the rendered radar, affecting only 1–2 frames at a time, on both `past` and `nowcast` frames — appearing for a frame or two of the animation loop, then gone.
- Orientation is a tell: the warmer renders tiles in row-major order (`[(x, y) for y in range(n) for x in range(n)]`), so a single mid-warm merge yields a **horizontal** boundary (the row the warmer had reached) with a **vertical** jog (the column within that row) — an L-shaped/staircase seam. The on-demand renderer can also mismatch at any adjacent tile edge.

## Root cause

`src/librewxr/data/store.py`, `FrameStore.add_frame`:

```python
# Merge into existing frame if same timestamp
for existing in self._frames:
    if existing.timestamp == frame.timestamp:
        existing.regions.update(frame.regions)   # in-place mutation
        return None, True
```

Region data for a timestamp arrives incrementally and re-enters `add_frame` for the same timestamp. Readers capture `frame.regions` by reference and iterate tiles **outside** the `add_frame` lock, so the `asyncio.Lock` doesn't protect them — an in-place `.update()` can swap a region array out from under a render already in flight.

## The fix

Swap the dict reference instead of mutating in place (copy-on-write):

```python
existing.regions = {**existing.regions, **frame.regions}
```

## Why it's safe

- `RadarFrame` is a plain (non-frozen) dataclass, so reassigning `existing.regions` is valid.
- Region arrays are never mutated in place anywhere — only dict membership changes — so an in-flight reader simply finishes on the snapshot it started with.
- New `get_frame` callers see the merged dict immediately.
- No extra array copies: only the (small) dict is rebuilt; the numpy/memmap arrays are shared.
- Same lock, same return contract — it purely removes the read-during-write hazard.

## Testing

- Frame-store and tile renderer/warmer tests pass with the change.
- Field: applied to a production CONUS+IFS single-mode deployment behind a CDN; the intermittent tile seams that previously appeared across the frame loop no longer occur once the CDN's per-timestamp cache rolls over to freshly-rendered tiles.