### PR TITLE
Default host to None (dual-stack) instead of 0.0.0.0 (IPv4-only)

### DIFF
--- a/src/librewxr/config.py
+++ b/src/librewxr/config.py
@@ -31,7 +31,7 @@ _MODE_DEFAULTS: dict[str, dict[str, int]] = {
 class Settings(BaseSettings):
     model_config = {"env_prefix": "LIBREWXR_", "env_file": ".env", "extra": "ignore"}
 
-    host: str = "0.0.0.0"
+    host: str | None = None
     port: int = 8080
     public_url: str = "http://localhost:8080"
     # Optional direct TLS termination.  Leave both unset (the default) to


### PR DESCRIPTION
## Summary

- Change default `host` bind from `0.0.0.0` (IPv4-only) to `None` (dual-stack)

## Problem

When LibreWXR runs inside Docker with dual-stack networking enabled, Docker publishes ports on both `0.0.0.0:8080` and `[::]:8080`. IPv6 connections arrive at the container's IPv6 address, but uvicorn only listens on `0.0.0.0` — so IPv6 connections silently fail.

Binding to `::` alone doesn't work either — Python's asyncio explicitly sets `IPV6_V6ONLY=1` on AF_INET6 sockets, making `::` IPv6-only regardless of the system sysctl.

## Fix

Default `host` to `None` instead of `0.0.0.0`. When uvicorn receives `host=None`, asyncio's `create_server` creates two sockets: one on `0.0.0.0` (IPv4) and one on `::` (IPv6 with `V6ONLY=1`). Both address families are served without port conflicts.

Operators can still override via `LIBREWXR_HOST=0.0.0.0` for IPv4-only or `LIBREWXR_HOST=::` for IPv6-only.

## Test plan

- [ ] `docker compose up` with dual-stack Docker network
- [ ] Verify `curl -4 http://localhost:8080/public/weather-maps.json` returns 200
- [ ] Verify `curl -6 http://[::1]:8080/public/weather-maps.json` returns 200
- [ ] Verify `LIBREWXR_HOST=0.0.0.0` override still works for IPv4-only deploys