### PR TITLE
Add a deadline to satellite background fetches so a hang can't freeze the layer

### DIFF
--- a/src/librewxr/config.py
+++ b/src/librewxr/config.py
@@ -103,6 +103,15 @@ class Settings(BaseSettings):
     # publishes one frame per hour, so 12 ≈ 12 hours of animation.
     # At ~15 MB per channel per frame, 12 × 2 channels ≈ 360 MB resident.
     satellite_max_frames: int = 12
+    # Deadline for one satellite fetch pass (list + download + decode of
+    # any missing hours in the retention window).  The per-channel fetch
+    # runs as a detached background task that is *skipped* — not retried —
+    # while the previous one is still running, so without a deadline a
+    # single hung S3 connection freezes the channel until restart while
+    # radar keeps updating.  A full 12-frame cold fill takes well under a
+    # minute on a slow link; 10 minutes is generous for steady state
+    # (one ~7.5 MB file per hour).
+    satellite_fetch_timeout: float = 600.0
     # US-side radar data source (USCOMP / AKCOMP / HICOMP / PRCOMP / GUCOMP).
     # Three modes:
     #   mrms_fallback  - (default) MRMS primary + IEM fallback when MRMS fails.

--- a/src/librewxr/data/fetcher.py
+++ b/src/librewxr/data/fetcher.py
@@ -386,9 +386,27 @@ class RadarFetcher:
         cycle-complete hook on success so render-only workers pick up
         new frames mid-cycle.  A failed fetch is warned and dropped;
         the next cycle retries.
+
+        The fetch runs under ``satellite_fetch_timeout``.  The scheduler
+        skips a channel while its previous task is still pending, so a
+        fetch that hangs (instead of failing) would otherwise freeze the
+        channel forever with no log above DEBUG.  On expiry the task
+        completes, the skip-gate opens, and the next cycle retries.  Note
+        the cancellation only abandons the coroutine — a worker thread
+        blocked inside a syscall lingers until its socket dies, which the
+        source's client-side timeouts keep bounded.
         """
         try:
-            new_frames = await contrib.instance.fetch()
+            new_frames = await asyncio.wait_for(
+                contrib.instance.fetch(), timeout=settings.satellite_fetch_timeout,
+            )
+        except TimeoutError:
+            logger.warning(
+                "%s fetch timed out after %.0fs, satellite layer may be stale",
+                contrib.name, settings.satellite_fetch_timeout,
+            )
+            release_memory()
+            return
         except Exception:
             logger.warning(
                 "%s fetch failed, satellite layer may be stale", contrib.name,

--- a/src/librewxr/sources/satellite/gmgsi/source.py
+++ b/src/librewxr/sources/satellite/gmgsi/source.py
@@ -141,7 +141,21 @@ class GMGSISource:
 
     def _get_fs(self) -> fsspec.AbstractFileSystem:
         if self._fs is None:
-            self._fs = fsspec.filesystem("s3", anon=True)
+            # Explicit botocore timeouts: the defaults can leave a stuck
+            # connection blocking the (thread-bridged) sync call for a very
+            # long time, and the pipeline skips a channel while its fetch
+            # task is pending — a hang here froze the satellite layer in
+            # production while radar kept updating.  Keep every network
+            # wait bounded so the fetch pass always finishes or fails.
+            self._fs = fsspec.filesystem(
+                "s3",
+                anon=True,
+                config_kwargs={
+                    "connect_timeout": 30,
+                    "read_timeout": 60,
+                    "retries": {"max_attempts": 3},
+                },
+            )
         return self._fs
 
     async def fetch(self) -> bool:

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -484,3 +484,80 @@ class TestCarryForward:
 
         carried = (await store.get_frame(1000 + interval)).regions["TESTREG"]
         assert carried[0, 0] == 77  # still readable, original value
+
+
+class _StubSatelliteInstance:
+    """Satellite source stand-in exposing only what the background task uses."""
+
+    def __init__(self, behavior):
+        self._behavior = behavior
+
+    async def fetch(self) -> bool:
+        return await self._behavior()
+
+
+class _StubSatelliteContribution:
+    def __init__(self, behavior, name="GMGSI LW"):
+        self.name = name
+        self.instance = _StubSatelliteInstance(behavior)
+
+
+def _build_satellite_fetcher():
+    """Bare fetcher with just the state _fetch_satellite_background touches."""
+    fetcher = RadarFetcher.__new__(RadarFetcher)
+    fetcher._on_cycle_complete = None
+    fetcher._satellite_tasks = {}
+    return fetcher
+
+
+class TestSatelliteBackgroundFetch:
+    async def test_hung_fetch_times_out_and_frees_the_skip_gate(
+        self, monkeypatch, caplog
+    ):
+        """A fetch that hangs must finish (via deadline) so later cycles retry.
+
+        The scheduler skips a channel while its previous task is pending;
+        before the deadline existed, one hung S3 call froze the channel
+        until restart with nothing logged above DEBUG.
+        """
+        from librewxr.config import settings
+
+        monkeypatch.setattr(settings, "satellite_fetch_timeout", 0.05)
+        fetcher = _build_satellite_fetcher()
+
+        async def hang() -> bool:
+            await asyncio.sleep(30)
+            return True
+
+        contrib = _StubSatelliteContribution(hang)
+        task = asyncio.create_task(fetcher._fetch_satellite_background(contrib))
+        with caplog.at_level("WARNING"):
+            await asyncio.wait_for(task, timeout=5)  # must not take ~30s
+
+        assert task.done()
+        assert any("timed out" in r.message for r in caplog.records)
+
+    async def test_successful_fetch_fires_cycle_complete(self):
+        fetcher = _build_satellite_fetcher()
+        fired = asyncio.Event()
+
+        async def on_complete() -> None:
+            fired.set()
+
+        fetcher._on_cycle_complete = on_complete
+
+        async def ok() -> bool:
+            return True
+
+        await fetcher._fetch_satellite_background(_StubSatelliteContribution(ok))
+        assert fired.is_set()
+
+    async def test_failed_fetch_is_dropped_with_a_warning(self, caplog):
+        fetcher = _build_satellite_fetcher()
+
+        async def boom() -> bool:
+            raise RuntimeError("s3 exploded")
+
+        with caplog.at_level("WARNING"):
+            await fetcher._fetch_satellite_background(_StubSatelliteContribution(boom))
+        assert any("fetch failed" in r.message for r in caplog.records)


### PR DESCRIPTION
## Problem

The per-channel satellite fetch runs as a detached background task, and the scheduler skips a channel while its previous task is still pending (`data/fetcher.py`):

```python
if existing is not None and not existing.done():
    logger.debug("%s fetch still running, skipping", contrib.name)
    continue
```

A fetch that **fails** is warned and retried next cycle, as the docstring promises. A fetch that **hangs**, however, keeps the task pending forever, so every later cycle skips it with nothing logged above DEBUG.

This happened in production: a network blip mid-fetch left both GMGSI channels' s3fs calls blocked (the S3 filesystem is created with no explicit timeouts), and the satellite layer silently froze for 11+ hours while radar kept updating. Log signature: a normal hourly `ingested 1 new frame(s)` cadence that simply stops, with no warnings after — while `noaa-gmgsi-pds` upstream kept publishing on schedule.

## Fix

Two bounded-wait guards, configurable via a new `satellite_fetch_timeout` setting (default 600 s):

- **`data/fetcher.py`** — wrap the background fetch in `asyncio.wait_for(...)` and log a WARNING on expiry. The task then completes, the skip-gate opens, and the next cycle retries. (`wait_for` cancels the coroutine; the `asyncio.to_thread` worker it abandons can still linger on a syscall, which is what the second guard bounds.)
- **`sources/satellite/gmgsi/source.py`** — give the s3fs client explicit botocore timeouts (`connect_timeout=30`, `read_timeout=60`, `retries={"max_attempts": 3}`) so no single network wait is unbounded.

## Tests

New `TestSatelliteBackgroundFetch` in `tests/test_fetcher.py`:
- a hung fetch times out, completes the task, and logs the warning (the regression case),
- a successful fetch still fires the cycle-complete hook,
- a failing fetch still warns and drops.

Full suite passes: 1046 passed.
