### PR TITLE
Serialize HDF5 access across threads to fix intermittent segfault

### DIFF
--- a/src/librewxr/sources/_helpers.py
+++ b/src/librewxr/sources/_helpers.py
@@ -12,6 +12,14 @@ Two helpers contributors reach for when implementing a new source:
   eccodes C library's non-actionable ``dataTime`` truncation noise.
   Used by every NWP source that opens GRIB2 (HRRR, HRRR-Alaska, HRDPS,
   ICON-EU, DMI DINI, AROME Antilles) and by the MRMS radar source.
+- ``HDF5_LOCK`` — a process-wide lock guarding every call into the
+  HDF5 C library (h5py, and xarray's ``engine="netcdf4"``).  HDF5 is
+  not thread-safe, and each of h5py/netCDF4's wheels bundles its own
+  private ``libhdf5`` build, so concurrent access from more than one
+  Python thread (e.g. one source parsing on the event loop while
+  another parses inside ``asyncio.to_thread``) corrupts the library's
+  internal state and segfaults the process. Used by OPERA (radar) and
+  WRF-SMN + GMGSI (NWP/satellite) — the only sources that touch HDF5.
 
 Both intentionally live outside any one source package so a new source
 can pick them up without importing from a sibling source's internals.
@@ -19,9 +27,12 @@ can pick them up without importing from a sibling source's internals.
 from __future__ import annotations
 
 import os
+import threading
 from contextlib import contextmanager
 
 import numpy as np
+
+HDF5_LOCK = threading.Lock()
 
 
 def _dbz_float_to_uint8(arr: np.ndarray) -> np.ndarray:

--- a/src/librewxr/sources/regional/europe/radar/opera/source.py
+++ b/src/librewxr/sources/regional/europe/radar/opera/source.py
@@ -25,7 +25,7 @@ import numpy as np
 
 from librewxr.data.regions import RegionDef
 from librewxr.data.retry import retry_get
-from librewxr.sources._helpers import _dbz_float_to_uint8
+from librewxr.sources._helpers import HDF5_LOCK, _dbz_float_to_uint8
 
 logger = logging.getLogger(__name__)
 
@@ -120,13 +120,13 @@ def _parse_opera_hdf5(data: bytes) -> np.ndarray | None:
     OPERA marks inconsistent swaths of ocean as "undetect."
     """
     try:
-        f = h5py.File(io.BytesIO(data), "r")
-        raw = f["dataset1/data1/data"][:]
-        what = f["dataset1/data1/what"]
-        nodata_val = float(what.attrs["nodata"])
-        undetect_val = float(what.attrs["undetect"])
-        gain = float(what.attrs["gain"])
-        offset = float(what.attrs["offset"])
+        with HDF5_LOCK, h5py.File(io.BytesIO(data), "r") as f:
+            raw = f["dataset1/data1/data"][:]
+            what = f["dataset1/data1/what"]
+            nodata_val = float(what.attrs["nodata"])
+            undetect_val = float(what.attrs["undetect"])
+            gain = float(what.attrs["gain"])
+            offset = float(what.attrs["offset"])
 
         # Apply gain/offset (usually 1.0/0.0 for OPERA CIRRUS)
         dbz = raw.astype(np.float32) * gain + offset

--- a/src/librewxr/sources/regional/south_america/nwp/wrf_smn/grid.py
+++ b/src/librewxr/sources/regional/south_america/nwp/wrf_smn/grid.py
@@ -50,6 +50,7 @@ import httpx
 import numpy as np
 
 from librewxr.config import settings
+from librewxr.sources._helpers import HDF5_LOCK
 from librewxr.sources.regional.north_america.usa.nwp.hrrr.grid import compute_snow_mask
 
 logger = logging.getLogger(__name__)
@@ -324,7 +325,7 @@ def decode_pp_message(nc_bytes: bytes) -> np.ndarray | None:
         with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
             tmp.write(nc_bytes)
             tmp_path = tmp.name
-        with h5py.File(tmp_path, "r") as f:
+        with HDF5_LOCK, h5py.File(tmp_path, "r") as f:
             if "PP" not in f:
                 logger.warning(
                     "WRF-SMN file has no 'PP' dataset (vars=%s)",
@@ -385,7 +386,7 @@ def decode_t2_message(nc_bytes: bytes) -> np.ndarray | None:
         with tempfile.NamedTemporaryFile(suffix=".nc", delete=False) as tmp:
             tmp.write(nc_bytes)
             tmp_path = tmp.name
-        with h5py.File(tmp_path, "r") as f:
+        with HDF5_LOCK, h5py.File(tmp_path, "r") as f:
             if "T2" not in f:
                 logger.warning(
                     "WRF-SMN file has no 'T2' dataset (vars=%s)",

--- a/src/librewxr/sources/satellite/gmgsi/source.py
+++ b/src/librewxr/sources/satellite/gmgsi/source.py
@@ -32,6 +32,8 @@ import fsspec
 import numpy as np
 import xarray as xr
 
+from librewxr.sources._helpers import HDF5_LOCK
+
 logger = logging.getLogger(__name__)
 
 # Grid constants.  Verified against a live LW file 2026-05-23 and
@@ -290,33 +292,34 @@ class GMGSISource:
         We mask pixels where ``dqf != 0`` (per CF convention 0=good)
         to 0, clip to [0, 255], and cast to uint8.
         """
-        ds = xr.open_dataset(path, engine="netcdf4", decode_times=False)
-        try:
-            data = ds["data"].values
-            # Strip time axis if present.
-            if data.ndim == 3 and data.shape[0] == 1:
-                data = data[0]
-            if data.shape != GRID_SHAPE:
-                logger.warning(
-                    "%s: unexpected grid shape %s, want %s — rejecting",
-                    self.friendly_name, data.shape, GRID_SHAPE,
-                )
-                return None
+        with HDF5_LOCK:
+            ds = xr.open_dataset(path, engine="netcdf4", decode_times=False)
+            try:
+                data = ds["data"].values
+                # Strip time axis if present.
+                if data.ndim == 3 and data.shape[0] == 1:
+                    data = data[0]
+                if data.shape != GRID_SHAPE:
+                    logger.warning(
+                        "%s: unexpected grid shape %s, want %s — rejecting",
+                        self.friendly_name, data.shape, GRID_SHAPE,
+                    )
+                    return None
 
-            # Apply quality mask when present.
-            if "dqf" in ds.variables:
-                dqf = ds["dqf"].values
-                if dqf.ndim == 3 and dqf.shape[0] == 1:
-                    dqf = dqf[0]
-                if dqf.shape == data.shape:
-                    data = np.where(dqf == 0, data, 0.0)
+                # Apply quality mask when present.
+                if "dqf" in ds.variables:
+                    dqf = ds["dqf"].values
+                    if dqf.ndim == 3 and dqf.shape[0] == 1:
+                        dqf = dqf[0]
+                    if dqf.shape == data.shape:
+                        data = np.where(dqf == 0, data, 0.0)
 
-            # Treat NaN / out-of-range as no-data sentinel (0).
-            data = np.where(np.isfinite(data), data, 0.0)
-            data = np.clip(data, 0, 255).astype(GRID_DTYPE)
-            return data
-        finally:
-            ds.close()
+                # Treat NaN / out-of-range as no-data sentinel (0).
+                data = np.where(np.isfinite(data), data, 0.0)
+                data = np.clip(data, 0, 255).astype(GRID_DTYPE)
+                return data
+            finally:
+                ds.close()
 
     # ── Cache (disk persistence + cross-worker snapshot) ──
 


### PR DESCRIPTION
HDF5 is not thread-safe, and each of h5py/netCDF4's wheels bundles its own private libhdf5 build. OPERA's radar parse runs on the event loop thread while WRF-SMN's and GMGSI's parses run in asyncio.to_thread workers, so concurrent NWP/radar fetch cycles could land two threads inside libhdf5 at the same instant and corrupt its internal state.

Confirmed via a production coredump: kernel logged "segfault ... in libhdf5-ba270836.so" from a container crashing every few hours under a stock config.

Add a shared HDF5_LOCK in _helpers.py and take it around every h5py.File(...) / xr.open_dataset(..., engine="netcdf4") call site (OPERA, WRF-SMN, GMGSI — the only sources touching HDF5; everything else uses cfgrib/eccodes, unaffected).