### PR TITLE
Fix ?cells= overlay silently dropped on warm geometry cache

### DIFF
--- a/src/librewxr/api/routes.py
+++ b/src/librewxr/api/routes.py
@@ -483,13 +483,16 @@ async def radar_tile(
             tile_request_tracker.record_cache_miss()
 
     # We need the radar frame whenever geometry must be computed AND
-    # whenever arrows are requested (arrow rendering needs live frame
-    # data + flow fields).  Skip the fetch on pure cache hits without
-    # arrows — that's the hot path Merry Sky-style clients exercise.
+    # whenever an overlay is requested: arrows need live frame data +
+    # flow fields, and cells need ``frame.regions`` to decide which
+    # regions actually carry data on this tile (without it
+    # ``_draw_storm_cells`` sees an empty region list and draws
+    # nothing).  Skip the fetch on pure cache hits without overlays —
+    # that's the hot path Merry Sky-style clients exercise.
     frame = None
     nowcast_blend = None
     is_nowcast = False
-    need_frame = geom is None or bool(arrow_style)
+    need_frame = geom is None or bool(arrow_style) or bool(cell_style)
     if need_frame:
         frame = await frame_store.get_frame(timestamp)
         if frame is None and nowcast_store is not None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,6 +47,46 @@ class _StubSatelliteSource:
         return np.full(lat.shape, self.value, dtype=np.uint8)
 
 
+class _StubStormCellStore:
+    """Duck-typed StormCellStore holding one cell centred on a given tile.
+
+    The centroid is derived from ``region_pixel_indices_fractional`` so it
+    is guaranteed to land inside the tile's coverage of the region, for
+    any projection — the same trick ``test_storm_cell_render.py`` uses.
+    """
+
+    def __init__(self, detected_at: int, region: str, z: int, x: int, y: int) -> None:
+        from librewxr.data.regions import REGIONS
+        from librewxr.data.storm_cells import _CELL_DTYPE
+        from librewxr.tiles.coordinates import (
+            region_pixel_indices,
+            region_pixel_indices_fractional,
+        )
+
+        region_def = REGIONS[region]
+        row_f, col_f = region_pixel_indices_fractional(region_def, z, x, y, 256)
+        row_i, _ = region_pixel_indices(region_def, z, x, y, 256)
+        valid = row_i >= 0
+        assert valid.any(), f"tile {z}/{x}/{y} does not cover {region}"
+
+        cell = np.zeros((1,), dtype=_CELL_DTYPE)
+        cell["centroid_row"][0] = float(row_f[valid].mean())
+        cell["centroid_col"][0] = float(col_f[valid].mean())
+        cell["area_km2"][0] = 500.0
+        cell["max_dbz"][0] = 55.0
+        cell["motion_speed_kmh"][0] = np.nan
+
+        self._cells = {region: cell}
+        self._counts = {region: 1}
+        self.detected_at_timestamp = detected_at
+
+    async def get_cells(self) -> dict[str, np.ndarray]:
+        return dict(self._cells)
+
+    async def get_counts(self) -> dict[str, int]:
+        return dict(self._counts)
+
+
 def _make_test_app() -> tuple[FastAPI, FrameStore, TileCache, int, int]:
     """Create a minimal FastAPI app with just the router — no lifespan."""
     store = FrameStore(max_frames=12)
@@ -212,6 +252,43 @@ class TestRadarTileEndpoint:
         assert etag.startswith('"')
         assert etag.endswith('"')
         assert len(etag) == 18
+
+    def test_cells_overlay_renders_on_warm_geometry_cache(self, client, monkeypatch):
+        """?cells= must draw even when the geometry cache already holds the tile.
+
+        Regression: ``need_frame`` only accounted for ``arrow_style``, so a
+        cells-only request that hit the geometry cache left ``frame`` unset.
+        ``present_tile`` then received ``frame_regions=None``, and
+        ``_draw_storm_cells`` fell back to an empty region list — the tile
+        came back byte-identical to the plain one, with no error.  In
+        production the cache is warm essentially always, so ?cells= looked
+        inert while ?arrows= (which forced the fetch) worked.
+        """
+        c, ts, _ = client
+        # 4/3/6 is the z=4 tile that actually covers the fixture's radar
+        # block — a transparent tile short-circuits before any overlay.
+        url = f"/v2/radar/{ts}/256/4/3/6/2/0_0.png"
+
+        # Warm the geometry cache first — that's the condition that used to
+        # silently disable the overlay.
+        plain = c.get(url)
+        assert plain.status_code == 200
+
+        monkeypatch.setattr(
+            routes, "storm_cell_store", _StubStormCellStore(ts, "USCOMP", 4, 3, 6),
+        )
+        with_cells = c.get(f"{url}?cells=1")
+        assert with_cells.status_code == 200
+        assert with_cells.content != plain.content
+
+    def test_cells_overlay_skipped_on_other_frames(self, client, monkeypatch):
+        """Cells only render on the frame detection actually ran on."""
+        c, ts, ts_prev = client
+        monkeypatch.setattr(
+            routes, "storm_cell_store", _StubStormCellStore(ts, "USCOMP", 4, 3, 6),
+        )
+        url = f"/v2/radar/{ts_prev}/256/4/3/6/2/0_0.png"
+        assert c.get(f"{url}?cells=1").content == c.get(url).content
 
 
 class TestCoverageTileEndpoint:


### PR DESCRIPTION
## Problem

`?cells=` on the radar tile endpoint renders nothing once the tile's geometry is in the cache — which, in production, is essentially always. The tile comes back `200 OK`, byte-identical to the plain tile, with no error and no log line. Meanwhile `/health` keeps reporting active cells, so the store looks healthy.

`?arrows=` is unaffected, which is what makes this confusing to diagnose from the outside: same endpoint, same overlay mechanism, one works and one doesn't.

## Cause

`radar_tile` only forces a frame fetch when arrows are requested:

```python
need_frame = geom is None or bool(arrow_style)
```

A cells-only request that hits the geometry cache therefore leaves `frame` unset. `present_tile` receives `frame_regions=None`, and `_draw_storm_cells` takes its `else` branch:

```python
if frame_regions:
    regions_with_data = [r for r in regions if r.name in frame_regions]
else:
    regions_with_data = []   # nothing is drawn
```

Arrows escape it because `bool(arrow_style)` forces the fetch. Cells need `frame.regions` for exactly the same reason arrows do — to know which regions carry data on this tile.

## Fix

Include `cell_style` in the condition. The comment above it is updated to state why cells need the frame, so the next person adding an overlay doesn't reintroduce it.

The second use of `need_frame` (the `tile_warmer` block) is unaffected: a `?cells=` request now takes the branch where `is_nowcast` is already computed.

## Why this wasn't caught

The existing `test_storm_cell_render.py` tests call `_draw_storm_cells` directly, so they never exercise the route's frame-fetch decision. A cold first render also works fine — the bug only appears on the second request for the same tile. Both added tests go through the route with a warmed cache.

- `test_cells_overlay_renders_on_warm_geometry_cache` — warms the cache, then asserts `?cells=1` produces a different tile. Fails on `main`, passes with the fix.
- `test_cells_overlay_skipped_on_other_frames` — locks in the intentional behaviour that cells only render on `detected_at_timestamp`. Happy to drop this one if you'd rather not pin that behaviour in a test.

## Testing

Full suite on this branch: 1297 passed. The 2 added tests are the only delta versus `main` — the remaining failures I see locally are identical with and without this change, so they look unrelated to it (and may well be environment-specific on my end).

Verified against a live deployment: cells now render on the latest observed frame, and correctly stay off past and nowcast frames.
