### PR TITLE
Refetch carry-forward slots while the source archive can still serve them

### DIFF
--- a/src/librewxr/data/fetcher.py
+++ b/src/librewxr/data/fetcher.py
@@ -53,6 +53,16 @@ class RadarFetcher:
     # masking a genuine multi-cycle outage.
     _CARRY_FORWARD_MAX_INTERVALS = 2
 
+    # A carried-forward region is a stale copy standing in for a product
+    # the source failed to serve.  Several sources can still serve the
+    # missed slot from a short archive window afterwards (Météo-France's
+    # DPPaquetRadar packet holds ~15 min), so carried slots stay eligible
+    # for re-fetch this many intervals back before being written off.
+    # Without the re-fetch, the stale copy permanently masks the slot:
+    # the store reports the region present, every later cycle skips it,
+    # and the animation keeps a frozen duplicate frame.
+    _CARRY_FORWARD_REFETCH_MAX_INTERVALS = 3
+
     # Debounce window for on_cycle_complete triggers (initial backfill,
     # end of cycle, frame merges, satellite background fetches).  Multiple
     # triggers within the window collapse into a single trailing-edge
@@ -105,6 +115,9 @@ class RadarFetcher:
         self._closed = False
         self._task: asyncio.Task | None = None
         self._satellite_tasks: dict[str, asyncio.Task] = {}
+        # Provenance of carry-forward fills: ts -> region names whose
+        # store entry is a stale copy, still awaiting the real product.
+        self._carried_regions: dict[int, set[str]] = {}
         self._enabled_regions = [
             REGIONS[name] for name in settings.get_enabled_regions()
         ]
@@ -586,13 +599,31 @@ class RadarFetcher:
         existing_frames = await self._store.get_region_keys()
         enabled_names = {r.name for r in self._enabled_regions}
 
+        # Prune carry-forward provenance for slots the source archive can
+        # no longer serve (or that left the store) — past that point the
+        # stale copy is final and retrying is wasted bandwidth.
+        refetch_cutoff = (
+            now_rounded - self._CARRY_FORWARD_REFETCH_MAX_INTERVALS * interval
+        )
+        for carried_ts in list(self._carried_regions):
+            if carried_ts < refetch_cutoff or carried_ts not in existing_frames:
+                del self._carried_regions[carried_ts]
+
         ts_and_sources: list[tuple[int, str, int | datetime]] = []
 
         for i in range(settings.max_frames):
             minutes_ago = i * interval_min
             ts = now_rounded - i * interval
 
-            if ts in existing_frames and enabled_names <= existing_frames[ts]:
+            # Carried-forward regions are stale copies; while their slot
+            # is inside the recovery window they count as missing so the
+            # real product can replace the copy (store merge + tile-cache
+            # invalidation handle the swap).
+            carried = self._carried_regions.get(ts, set())
+            if (
+                ts in existing_frames
+                and enabled_names <= existing_frames[ts] - carried
+            ):
                 continue
 
             # IEM live endpoint covers 0-55 min ago
@@ -618,7 +649,10 @@ class RadarFetcher:
         Args:
             skip_regions: Optional mapping of timestamp -> region names to
                 skip (already present in the store).  Only missing regions
-                are fetched, saving bandwidth on retries for incomplete frames.
+                are fetched, saving bandwidth on retries for incomplete
+                frames.  Regions recorded in ``_carried_regions`` are
+                fetched despite being present — their store entry is a
+                carry-forward copy awaiting the real product.
         """
         # For each timestamp, fetch regions in parallel (skipping any
         # already present from a previous partial fetch).
@@ -627,8 +661,9 @@ class RadarFetcher:
 
         for ts, source_type, source_arg in ts_and_sources:
             have = skip_regions.get(ts, set()) if skip_regions else set()
+            carried = self._carried_regions.get(ts, set())
             for region in self._enabled_regions:
-                if region.name in have:
+                if region.name in have and region.name not in carried:
                     continue
                 source = self._sources[region.name]
                 if source_type == "live":
@@ -690,6 +725,14 @@ class RadarFetcher:
 
             frames_by_ts[ts][region.name] = result
 
+            # Real data landed — retire any carry-forward provenance so
+            # later cycles stop re-fetching this slot.
+            carried_here = self._carried_regions.get(ts)
+            if carried_here is not None:
+                carried_here.discard(region.name)
+                if not carried_here:
+                    del self._carried_regions[ts]
+
         # Store frames in chronological order so carry-forward lookback
         # sees the freshest data (a backfill cycle that fetches several
         # timestamps at once needs the older frames stored before the
@@ -727,6 +770,9 @@ class RadarFetcher:
                             "%s: carry-forward into ts=%d from %d (%d min stale)",
                             name, ts, prev_ts, stale_min,
                         )
+                        # Record provenance so later cycles re-fetch this
+                        # slot while the source archive can still serve it.
+                        self._carried_regions.setdefault(ts, set()).add(name)
                         missing.discard(name)
 
             if not regions_data:

--- a/tests/test_fetcher.py
+++ b/tests/test_fetcher.py
@@ -189,6 +189,9 @@ def _build_fetcher(store, tile_cache, radar_cache, region):
     fetcher._store = store
     fetcher._cache = tile_cache
     fetcher._nwp_contributions = []
+    fetcher._satellite_contributions = []
+    fetcher._satellite_tasks = {}
+    fetcher._carried_regions = {}
     fetcher._nowcast_generator = None
     fetcher._warmer = None
     fetcher._radar_cache = radar_cache
@@ -484,6 +487,173 @@ class TestCarryForward:
 
         carried = (await store.get_frame(1000 + interval)).regions["TESTREG"]
         assert carried[0, 0] == 77  # still readable, original value
+
+
+class TestCarryForwardRefetch:
+    """A carried-forward region must not permanently mask the slot.
+
+    Sources like Météo-France serve missed slots from a short archive
+    window (the DPPaquetRadar packet, ~15 min).  When a live fetch
+    fails and the slot is bridged by carry-forward, later cycles must
+    re-fetch that slot while it is still recoverable — otherwise the
+    stale duplicate frame is frozen into the timeline forever (visible
+    as a stutter/gap in the animation).
+    """
+
+    @pytest.fixture
+    def small_region(self):
+        return RegionDef(
+            name="TESTREG",
+            west=0.0, east=3.2, south=0.0, north=3.2,
+            pixel_size=0.1, group="US",
+            grid_width=32, grid_height=32,
+        )
+
+    def _clocked_fetcher(self, monkeypatch, small_region, max_frames=3):
+        from librewxr.config import settings
+        interval = settings.fetch_interval
+
+        monkeypatch.setattr(settings, "max_frames", max_frames)
+        clock = {"now": float(1000 * interval)}
+        monkeypatch.setattr(
+            "librewxr.data.fetcher.time.time", lambda: clock["now"],
+        )
+
+        store = FrameStore(max_frames=max_frames + 4)
+        tile_cache = TileCache(max_mb=1)
+        fetcher, source = _build_fetcher(
+            store, tile_cache, None, small_region,
+        )
+        return fetcher, source, store, clock, interval
+
+    @pytest.mark.asyncio
+    async def test_carried_region_is_refetched_on_next_cycle(
+        self, monkeypatch, small_region,
+    ):
+        fetcher, source, store, clock, interval = self._clocked_fetcher(
+            monkeypatch, small_region,
+        )
+        ts0 = int(clock["now"])
+
+        # Cycle 1: healthy — three timestamps land with value 77.
+        source.fill_value = 77
+        await fetcher._fetch_all_frames()
+
+        # Cycle 2: live slot drops silently -> carry-forward from ts0.
+        clock["now"] += interval
+        dropped_ts = int(clock["now"])
+        source.next_return = None
+        source.fill_value = 99
+        await fetcher._fetch_all_frames()
+        assert (await store.get_frame(dropped_ts)).regions["TESTREG"][0, 0] == 77
+
+        # Cycle 3: the source can now serve the slot.  The fetcher must
+        # re-fetch the carried slot instead of treating it as complete.
+        clock["now"] += interval
+        source.fill_value = 111
+        await fetcher._fetch_all_frames()
+        assert (await store.get_frame(dropped_ts)).regions["TESTREG"][0, 0] == 111
+
+    @pytest.mark.asyncio
+    async def test_successful_refetch_clears_the_retry(
+        self, monkeypatch, small_region,
+    ):
+        """Once real data replaces the carried copy, later cycles skip
+        the slot again — no endless re-downloads."""
+        fetcher, source, store, clock, interval = self._clocked_fetcher(
+            monkeypatch, small_region,
+        )
+
+        source.fill_value = 77
+        await fetcher._fetch_all_frames()
+
+        clock["now"] += interval
+        source.next_return = None
+        await fetcher._fetch_all_frames()
+
+        clock["now"] += interval
+        source.fill_value = 111
+        await fetcher._fetch_all_frames()
+
+        # Cycle 4: only the brand-new live slot should be fetched.
+        clock["now"] += interval
+        n_before = len(source.live_calls)
+        await fetcher._fetch_all_frames()
+        assert source.live_calls[n_before:] == [("TESTREG", 0)]
+
+    @pytest.mark.asyncio
+    async def test_refetch_stops_outside_recovery_window(
+        self, monkeypatch, small_region,
+    ):
+        """A carried slot older than the recovery window is left alone —
+        the source archive can no longer serve it, so retrying is waste."""
+        fetcher, source, store, clock, interval = self._clocked_fetcher(
+            monkeypatch, small_region, max_frames=8,
+        )
+
+        source.fill_value = 77
+        await fetcher._fetch_all_frames()
+
+        clock["now"] += interval
+        stale_ts = int(clock["now"])
+        source.next_return = None
+        await fetcher._fetch_all_frames()
+
+        # Jump past the recovery window in one leap.  The intervening
+        # slots are brand-new fetches; the carried slot must NOT be
+        # among the fetched timestamps.
+        leap = RadarFetcher._CARRY_FORWARD_REFETCH_MAX_INTERVALS + 1
+        clock["now"] += leap * interval
+        source.fill_value = 111
+        n_before = len(source.live_calls) + len(source.archive_calls)
+        await fetcher._fetch_all_frames()
+
+        new_live = source.live_calls[n_before:]
+        fetched_ts = {
+            int(clock["now"]) - m * 60 for _, m in new_live
+        }
+        assert stale_ts not in fetched_ts
+        assert (await store.get_frame(stale_ts)).regions["TESTREG"][0, 0] == 77
+
+    @pytest.mark.asyncio
+    async def test_failed_refetch_leaves_frame_untouched_and_retries(
+        self, monkeypatch, small_region,
+    ):
+        """A refetch that fails again must not rewrite the carried frame
+        (no version bump / tile-cache churn) and must stay eligible for
+        retry on the following cycle."""
+        fetcher, source, store, clock, interval = self._clocked_fetcher(
+            monkeypatch, small_region,
+        )
+
+        source.fill_value = 77
+        await fetcher._fetch_all_frames()
+
+        clock["now"] += interval
+        dropped_ts = int(clock["now"])
+        source.next_return = None
+        await fetcher._fetch_all_frames()
+        version_after_carry = store._frame_versions[dropped_ts]
+
+        # Cycle 3: everything fails (new slot AND the refetch).
+        async def always_none(region, minutes_ago):
+            source.live_calls.append((region.name, minutes_ago))
+            return None
+
+        real_fetch = source.fetch_frame
+        source.fetch_frame = always_none
+        clock["now"] += interval
+        await fetcher._fetch_all_frames()
+
+        assert (await store.get_frame(dropped_ts)).regions["TESTREG"][0, 0] == 77
+        assert store._frame_versions[dropped_ts] == version_after_carry
+
+        # Cycle 4: source recovers — the slot is still retried and healed.
+        source.fetch_frame = real_fetch
+        source.fill_value = 111
+        clock["now"] += interval
+        await fetcher._fetch_all_frames()
+        assert (await store.get_frame(dropped_ts)).regions["TESTREG"][0, 0] == 111
 
 
 class _StubSatelliteInstance:


### PR DESCRIPTION
## Problem

When a live fetch fails transiently (upstream 500, late publication), the fetcher bridges the slot by carry-forward — but the copied region then counts as *present* in the store, so the skip test in `_fetch_all_frames` never re-fetches that slot. The stale duplicate is permanent, even though many sources can still serve the missed product from a short archive window (OPERA's 24 h S3 archive, DPC's REST API, MRMS directory listings…). Visually: the animation freezes for one frame then jumps, which users report as "holes" in the radar.

The store already has the machinery for the recovery (merge-on-duplicate-ts + version bump, with a comment describing exactly this "carried forward then filled in" case) — it was just unreachable, because nothing ever re-fetched a carried slot.

## Fix

The fetcher now records carry-forward provenance (`_carried_regions`) and treats those regions as missing for up to `_CARRY_FORWARD_REFETCH_MAX_INTERVALS` (3) intervals, so the next cycles re-fetch the slot through the source's archive path. When real data lands, the existing merge path swaps it in and invalidates cached tiles. A refetch that fails again leaves the frame untouched (no version-bump/cache churn) and stays eligible until the window closes; past the window the provenance is pruned and the copy becomes final.

## Tests

4 new tests in `tests/test_fetcher.py` (`TestCarryForwardRefetch`): recovery on the next cycle, no endless re-downloads after success, no retries past the recovery window, and failed refetch leaves the frame untouched while remaining eligible.

Running in production on my instance (5-min cadence, multiple sources) since 2026-08-06 — transient upstream errors that previously froze a frame permanently now heal at the following cycle.